### PR TITLE
aws_lb_target_group: always support ip_address_type

### DIFF
--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -390,11 +390,8 @@ func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 			input.ProtocolVersion = aws.String(d.Get("protocol_version").(string))
 		}
 		input.VpcId = aws.String(d.Get("vpc_id").(string))
-
-		if targetType == elbv2.TargetTypeEnumIp {
-			if v, ok := d.GetOk("ip_address_type"); ok {
-				input.IpAddressType = aws.String(v.(string))
-			}
+		if v, ok := d.GetOk("ip_address_type"); ok {
+			input.IpAddressType = aws.String(v.(string))
 		}
 	}
 


### PR DESCRIPTION
ip_address_type is supported for both type instance and type IP

Fixes #35010

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
